### PR TITLE
feat : id_token을 웹 api로 가져오는 기능 

### DIFF
--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/presentation/CredentialController.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/presentation/CredentialController.java
@@ -4,12 +4,10 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
+import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.request.OauthCodeRequest;
 import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.request.RegisterRequest;
 import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.request.TokenRefreshRequest;
-import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response.AccessTokenDto;
-import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response.AuthTokensResponse;
-import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response.CheckRegisteredResponse;
-import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response.OauthLoginLinkResponse;
+import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response.*;
 import uttugseuja.lucklotteryserver.domain.credential.service.CredentialService;
 import uttugseuja.lucklotteryserver.domain.credential.service.OauthProvider;
 import java.security.NoSuchAlgorithmException;
@@ -38,6 +36,12 @@ public class CredentialController {
     @GetMapping("/oauth/link/kakao")
     public OauthLoginLinkResponse getKakaoOauthLink() {
         return new OauthLoginLinkResponse(credentialService.getOauthLink(OauthProvider.KAKAO));
+    }
+
+    @GetMapping("/oauth/kakao")
+    public AfterOauthResponse kakaoAuth(OauthCodeRequest oauthCodeRequest) {
+        log.info("code = {}",oauthCodeRequest.getCode());
+        return credentialService.getIdTokenToCode(OauthProvider.KAKAO, oauthCodeRequest.getCode());
     }
 
     @GetMapping("/oauth/valid/register")

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/presentation/CredentialController.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/presentation/CredentialController.java
@@ -9,13 +9,12 @@ import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.request.T
 import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response.AccessTokenDto;
 import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response.AuthTokensResponse;
 import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response.CheckRegisteredResponse;
+import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response.OauthLoginLinkResponse;
 import uttugseuja.lucklotteryserver.domain.credential.service.CredentialService;
 import uttugseuja.lucklotteryserver.domain.credential.service.OauthProvider;
-import uttugseuja.lucklotteryserver.domain.user.domain.User;
-
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
-import java.util.UUID;
+
 
 @RestController
 @RequestMapping("/api/v1/credentials")
@@ -36,6 +35,10 @@ public class CredentialController {
         credentialService.singUpTest(registerRequest);
     }
 
+    @GetMapping("/oauth/link/kakao")
+    public OauthLoginLinkResponse getKakaoOauthLink() {
+        return new OauthLoginLinkResponse(credentialService.getOauthLink(OauthProvider.KAKAO));
+    }
 
     @GetMapping("/oauth/valid/register")
     public CheckRegisteredResponse valid(

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/presentation/dto/request/OauthCodeRequest.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/presentation/dto/request/OauthCodeRequest.java
@@ -1,0 +1,10 @@
+package uttugseuja.lucklotteryserver.domain.credential.presentation.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OauthCodeRequest {
+    private String code;
+}

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/presentation/dto/response/AfterOauthResponse.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/presentation/dto/response/AfterOauthResponse.java
@@ -1,0 +1,11 @@
+package uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AfterOauthResponse {
+    private String idToken;
+}

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/presentation/dto/response/OauthLoginLinkResponse.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/presentation/dto/response/OauthLoginLinkResponse.java
@@ -1,0 +1,11 @@
+package uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OauthLoginLinkResponse {
+
+    private String link;
+}

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/CredentialService.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/CredentialService.java
@@ -64,6 +64,11 @@ public class CredentialService {
         return new CheckRegisteredResponse(isRegistered);
     }
 
+    public String getOauthLink(OauthProvider oauthProvider) {
+        OauthStrategy oauthStrategy = oauthFactory.getOauthstrategy(oauthProvider);
+        return oauthStrategy.getOauthLink();
+    }
+
     private Boolean checkUserCanRegister(
             OIDCDecodePayload oidcDecodePayload, OauthProvider oauthProvider) {
         Optional<User> user =

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/CredentialService.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/CredentialService.java
@@ -9,6 +9,7 @@ import uttugseuja.lucklotteryserver.domain.credential.domain.repository.RefreshT
 import uttugseuja.lucklotteryserver.domain.credential.exception.RefreshTokenExpiredException;
 import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.request.RegisterRequest;
 import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response.AccessTokenDto;
+import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response.AfterOauthResponse;
 import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response.AuthTokensResponse;
 import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response.CheckRegisteredResponse;
 import uttugseuja.lucklotteryserver.domain.user.domain.User;
@@ -55,6 +56,15 @@ public class CredentialService {
                         .nickname(registerRequest.getNickname())
                         .build();
         userRepository.save(user);
+    }
+
+    @Transactional
+    public AfterOauthResponse getIdTokenToCode(OauthProvider oauthProvider, String code) {
+        OauthStrategy oauthStrategy = oauthFactory.getOauthstrategy(oauthProvider);
+        log.info("oauthStrategy ={}" ,oauthStrategy);
+        String idToken = oauthStrategy.getIdToken(code);
+        log.info("idToken ={}" ,idToken);
+        return new AfterOauthResponse(idToken);
     }
 
     public CheckRegisteredResponse getUserAvailableRegister(String token, OauthProvider oauthProvider) throws NoSuchAlgorithmException, InvalidKeySpecException {

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/GoogleOauthStrategy.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/GoogleOauthStrategy.java
@@ -22,5 +22,15 @@ public class GoogleOauthStrategy implements OauthStrategy{
         return oauthOIDCProvider.getPayloadFromIdToken(token,ISSUER,oauthProperties.getKakaoAppId(),oidcKakaoKeysResponse);
     }
 
+    @Override
+    public String getOauthLink() {
+        return null;
+    }
+
+    @Override
+    public String getIdToken(String code) {
+        return null;
+    }
+
 
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/KaKaoOauthStrategy.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/KaKaoOauthStrategy.java
@@ -7,8 +7,7 @@ import uttugseuja.lucklotteryserver.global.api.client.KakaoOauthClient;
 import uttugseuja.lucklotteryserver.global.api.dto.OIDCKeysResponse;
 import uttugseuja.lucklotteryserver.global.property.OauthProperties;
 
-import java.security.NoSuchAlgorithmException;
-import java.security.spec.InvalidKeySpecException;
+
 
 
 @AllArgsConstructor
@@ -40,6 +39,11 @@ public class KaKaoOauthStrategy implements OauthStrategy {
 
     @Override
     public String getIdToken(String code) {
-        return null;
+        return kakaoOauthClient
+                .kakaoAuth(
+                        oauthProperties.getKakaoClientId(),
+                        oauthProperties.getKakaoRedirectUrl(),
+                        code)
+                .getIdToken();
     }
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/KaKaoOauthStrategy.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/KaKaoOauthStrategy.java
@@ -20,11 +20,26 @@ public class KaKaoOauthStrategy implements OauthStrategy {
     private final KakaoOauthClient kakaoOauthClient;
     private final OauthOIDCProvider oauthOIDCProvider;
     private static final String ISSUER = "https://kauth.kakao.com";
+    private static final String QUERY_STRING = "/oauth/authorize?client_id=%s&redirect_uri=%s&response_type=code";
 
 
     @Override
     public OIDCDecodePayload getOIDCDecodePayload(String token){
         OIDCKeysResponse oidcKakaoKeysResponse = kakaoOauthClient.getKakaoOIDCOpenKeys();
         return oauthOIDCProvider.getPayloadFromIdToken(token,ISSUER,oauthProperties.getKakaoAppId(),oidcKakaoKeysResponse);
+    }
+
+    @Override
+    public String getOauthLink() {
+        return oauthProperties.getKakaoBaseUrl()
+                + String.format(
+                QUERY_STRING,
+                oauthProperties.getKakaoClientId(),
+                oauthProperties.getKakaoRedirectUrl());
+    }
+
+    @Override
+    public String getIdToken(String code) {
+        return null;
     }
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/OauthStrategy.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/OauthStrategy.java
@@ -4,5 +4,9 @@ import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 
 public interface OauthStrategy {
-    OIDCDecodePayload getOIDCDecodePayload(String token) throws NoSuchAlgorithmException, InvalidKeySpecException;
+    OIDCDecodePayload getOIDCDecodePayload(String token);
+
+    String getOauthLink();
+
+    String getIdToken(String code);
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/global/api/client/KakaoOauthClient.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/global/api/client/KakaoOauthClient.java
@@ -1,10 +1,14 @@
 package uttugseuja.lucklotteryserver.global.api.client;
 
 
+import feign.Headers;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import uttugseuja.lucklotteryserver.global.api.dto.OIDCKeysResponse;
+import uttugseuja.lucklotteryserver.global.api.dto.OauthIdTokenResponse;
 
 @FeignClient(name = "KakaoAuthClient", url = "https://kauth.kakao.com")
 public interface KakaoOauthClient {
@@ -12,4 +16,12 @@ public interface KakaoOauthClient {
     @Cacheable(cacheNames = "KakaoOICD", cacheManager = "oidcKeyCacheManager")
     @GetMapping("/.well-known/jwks.json")
     OIDCKeysResponse getKakaoOIDCOpenKeys();
+
+    @Headers("Content-type: application/x-www-form-urlencoded;charset=utf-8")
+    @PostMapping(
+            "/oauth/token?grant_type=authorization_code&client_id={CLIENT_ID}&redirect_uri={REDIRECT_URI}&code={CODE}")
+    OauthIdTokenResponse kakaoAuth(
+            @PathVariable("CLIENT_ID") String clientId,
+            @PathVariable("REDIRECT_URI") String redirectUri,
+            @PathVariable("CODE") String code);
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/global/api/dto/OauthIdTokenResponse.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/global/api/dto/OauthIdTokenResponse.java
@@ -1,0 +1,12 @@
+package uttugseuja.lucklotteryserver.global.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OauthIdTokenResponse {
+    @JsonProperty("id_token")
+    private String idToken;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,9 @@ logging.level:
 oauth:
   kakao:
     app-id: ${KAKAO_APP_ID}
+    client-id: ${CLIENT_ID}
+    redirect-url: ${REDIRECT_URL}
+    base-url: ${BASE_URL}
   google:
     app-id: ${GOOGLE_APP_ID}
 


### PR DESCRIPTION
resolved: #40 
## 작업 내용
- 카카오 로그인 화면을 받을 수 있는 링크 가져오기 기능 구현 
- 인가 code를 받아오는 기능
- Redirect-url을 통해서 받아온 code를 카카오 서버로 보내서 id_token을 가져오는 기능


## 전달사항 
- 현재 웹을 통해 id_token을 받아오는 기능을 구현했지만 앱키 인증이 현재 네이티브 앱키로 되어있어서 test시에는 REST API 키로 인증을 바꿔야하는 로직 구현 예정 
