### PR TITLE
fix : random pension lottery round

### DIFF
--- a/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/domain/PensionLottery.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/domain/PensionLottery.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import uttugseuja.lucklotteryserver.domain.lottery.domain.vo.LotteryBaseInfoVo;
+import uttugseuja.lucklotteryserver.domain.pensionlottery.domain.vo.PensionLotteryBaseInfoVo;
 import uttugseuja.lucklotteryserver.domain.user.domain.User;
 import uttugseuja.lucklotteryserver.global.common.Rank;
 import uttugseuja.lucklotteryserver.global.database.BaseEntity;
@@ -61,6 +63,23 @@ public class PensionLottery extends BaseEntity {
         this.pensionFourthNum = pensionFourthNum;
         this.pensionFifthNum = pensionFifthNum;
         this.pensionSixthNum = pensionSixthNum;
+    }
+
+    public PensionLotteryBaseInfoVo getPensionLotteryBaseInfoVo() {
+        return PensionLotteryBaseInfoVo.builder()
+                .pensionLotteryId(id)
+                .rank(rank)
+                .pensionRound(pensionRound)
+                .pensionGroup(pensionGroup)
+                .pensionFirstNum(pensionFirstNum)
+                .pensionSecondNum(pensionSecondNum)
+                .pensionThirdNum(pensionThirdNum)
+                .pensionFourthNum(pensionFourthNum)
+                .pensionFifthNum(pensionFifthNum)
+                .pensionSixthNum(pensionSixthNum)
+                .createdDate(getCreatedDate())
+                .lastModifyDate(getLastModifyDate())
+                .build();
     }
 
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/domain/repository/PensionLotteryRepository.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/domain/repository/PensionLotteryRepository.java
@@ -8,5 +8,5 @@ import uttugseuja.lucklotteryserver.domain.user.domain.User;
 import java.util.List;
 
 public interface PensionLotteryRepository extends JpaRepository<PensionLottery, Long> {
-
+    List<PensionLottery> findByUserId(Long id);
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/domain/vo/PensionLotteryBaseInfoVo.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/domain/vo/PensionLotteryBaseInfoVo.java
@@ -1,0 +1,25 @@
+package uttugseuja.lucklotteryserver.domain.pensionlottery.domain.vo;
+
+import lombok.Builder;
+import lombok.Getter;
+import uttugseuja.lucklotteryserver.global.common.Rank;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PensionLotteryBaseInfoVo {
+
+    private final Long pensionLotteryId;
+    private final Integer pensionRound;
+    private final Integer pensionGroup;
+    private final Integer pensionFirstNum;
+    private final Integer pensionSecondNum;
+    private final Integer pensionThirdNum;
+    private final Integer pensionFourthNum;
+    private final Integer pensionFifthNum;
+    private final Integer pensionSixthNum;
+    private final Rank rank;
+    private LocalDateTime createdDate;
+    private LocalDateTime lastModifyDate;
+}
+

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/service/PensionLotteryService.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/service/PensionLotteryService.java
@@ -13,6 +13,8 @@ import uttugseuja.lucklotteryserver.domain.pensionlottery.presentation.dto.reque
 import uttugseuja.lucklotteryserver.domain.pensionlottery.presentation.dto.response.RandomPensionLotteryResponse;
 import uttugseuja.lucklotteryserver.domain.user.domain.User;
 import uttugseuja.lucklotteryserver.global.utils.user.UserUtils;
+
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -30,6 +32,11 @@ public class PensionLotteryService {
         List<Integer> numbers = createRandomPensionNumbers();
         WinningPensionLottery winningPensionLottery = winningPensionLotteryService.getRecentWinningPensionLottery();
         Integer randomRound = winningPensionLottery.getRound() + 1;
+
+        if(LocalDateTime.now().isAfter(winningPensionLottery.getLotteryDrawTime().plusDays(7))){
+            randomRound+=1;
+        }
+
         return new RandomPensionLotteryResponse(numbers,randomRound);
     }
 

--- a/src/main/java/uttugseuja/lucklotteryserver/global/scheduler/WinningPensionLotteryUpdateScheduling.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/global/scheduler/WinningPensionLotteryUpdateScheduling.java
@@ -18,7 +18,7 @@ public class WinningPensionLotteryUpdateScheduling {
     private final WinningPensionLotteryService winningPensionLotteryService;
     private final WinningPensionLotteryRepository winningPensionLotteryRepository;
 
-    @Scheduled(cron = "0 0/2 * * * *")
+    //@Scheduled(cron = "0 0/2 * * * *")
     //@Scheduled(cron = "0 30/2 19-20 * * THU") 매주 목요일 19시 30분부터 20시 30분까지 2분마다
     @Transactional
     public void chatCaching() throws LuckLotteryIoException {


### PR DESCRIPTION
resolved: #67 
## 작업내용
- 연금 복권 랜덤 제공에서 회차 수를 연급 복권 추첨 날짜 저녁 5시 이후에는 다음 회차로 저장으로 수정
- pension_rottery vo 생성

