### PR TITLE
fix : 사용자 연금복권 목록 조회 로직 변경

### DIFF
--- a/src/main/java/uttugseuja/lucklotteryserver/domain/WinningPensionlottery/service/WinningPensionLotteryService.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/WinningPensionlottery/service/WinningPensionLotteryService.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
 @RequiredArgsConstructor
 @Service
 @Slf4j
-public class WinningPensionLotteryService {
+public class WinningPensionLotteryService implements WinningPensionLotteryUtils{
 
     private final WinningPensionLotteryJdbcRepository winningPensionLotteryJdbcRepository;
     private final WinningPensionLotteryRepository winningPensionLotteryRepository;
@@ -45,12 +45,14 @@ public class WinningPensionLotteryService {
         return new WinningPensionLotteryResponse(recentWinningPensionLottery.getWinningPensionLotteryBaseInfoVo());
     }
 
+    @Override
     public WinningPensionLottery getRecentWinningPensionLottery() {
         return winningPensionLotteryRepository
                 .findFirstByOrderByRoundDesc()
                 .orElseThrow(()-> WinningPensionLotteryNotFoundException.EXCEPTION);
     }
 
+    @Override
     public WinningPensionLottery getRecentWinningPensionLotteryByRound(Integer round) {
         return winningPensionLotteryRepository
                 .findByRound(round)

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/WinningPensionlottery/service/WinningPensionLotteryUtils.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/WinningPensionlottery/service/WinningPensionLotteryUtils.java
@@ -1,0 +1,11 @@
+package uttugseuja.lucklotteryserver.domain.WinningPensionlottery.service;
+
+import uttugseuja.lucklotteryserver.domain.WinningPensionlottery.domain.WinningPensionLottery;
+
+public interface WinningPensionLotteryUtils {
+
+     WinningPensionLottery getRecentWinningPensionLottery();
+
+     WinningPensionLottery getRecentWinningPensionLotteryByRound(Integer round);
+
+}

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/domain/repository/PensionLotteryRepository.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/domain/repository/PensionLotteryRepository.java
@@ -19,4 +19,7 @@ public interface PensionLotteryRepository extends JpaRepository<PensionLottery, 
     @Query("select distinct p.pensionRound from PensionLottery p where p.user = :user order by p.pensionRound desc")
     Slice<Integer> findRoundByUser(User user, Pageable pageable);
 
+    @Query("SELECT p FROM PensionLottery p WHERE p.user = :user AND p.pensionRound IN :rounds")
+    List<PensionLottery> findPensionLotteryByRounds(@Param("user") User user, @Param("rounds") List<Integer> rounds);
+
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/domain/repository/PensionLotteryRepository.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/domain/repository/PensionLotteryRepository.java
@@ -16,4 +16,7 @@ public interface PensionLotteryRepository extends JpaRepository<PensionLottery, 
     @Query("select p from PensionLottery p where p.user = :user and p.rank is null and p.pensionRound <= :pensionRound")
     List<PensionLottery> drawnPensionLottery(User user, Integer pensionRound);
 
+    @Query("select distinct p.pensionRound from PensionLottery p where p.user = :user order by p.pensionRound desc")
+    Slice<Integer> findRoundByUser(User user, Pageable pageable);
+
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/domain/repository/PensionLotteryRepository.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/domain/repository/PensionLotteryRepository.java
@@ -3,14 +3,17 @@ package uttugseuja.lucklotteryserver.domain.pensionlottery.domain.repository;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-import uttugseuja.lucklotteryserver.domain.lottery.domain.Lottery;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import uttugseuja.lucklotteryserver.domain.pensionlottery.domain.PensionLottery;
 import uttugseuja.lucklotteryserver.domain.user.domain.User;
-
 import java.util.List;
 
 public interface PensionLotteryRepository extends JpaRepository<PensionLottery, Long> {
-    //List<PensionLottery> findByUserId(Long id);
 
     Slice<PensionLottery> findByUserId(Long userId, Pageable pageable);
+
+    @Query("select p from PensionLottery p where p.user = :user and p.rank is null and p.pensionRound <= :pensionRound")
+    List<PensionLottery> drawnPensionLottery(User user, Integer pensionRound);
+
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/presentation/dto/request/CreatePensionLotteryRequest.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/presentation/dto/request/CreatePensionLotteryRequest.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class CreatePensionLotteryRequest {
 
-    private Integer pensionRound;
     private Integer pensionGroup;
     private Integer pensionFirstNum;
     private Integer pensionSecondNum;

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/presentation/dto/response/PensionLotteryNumbersResponse.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/presentation/dto/response/PensionLotteryNumbersResponse.java
@@ -2,6 +2,9 @@ package uttugseuja.lucklotteryserver.domain.pensionlottery.presentation.dto.resp
 
 import lombok.Getter;
 import uttugseuja.lucklotteryserver.domain.pensionlottery.domain.vo.PensionLotteryBaseInfoVo;
+import uttugseuja.lucklotteryserver.global.common.Rank;
+
+import java.util.List;
 
 @Getter
 public class PensionLotteryNumbersResponse {
@@ -13,14 +16,22 @@ public class PensionLotteryNumbersResponse {
     private Integer pensionFourthNum;
     private Integer pensionFifthNum;
     private Integer pensionSixthNum;
+    private Rank rank;
+    private Boolean checkWinningBonus;
+    private List<Boolean> correctNumbers;
+    private List<Boolean> bonusCorrectNumbers;
 
-    public PensionLotteryNumbersResponse(PensionLotteryBaseInfoVo pensionLotteryBaseInfoVo) {
-        pensionGroup = pensionLotteryBaseInfoVo.getPensionGroup();
-        pensionFirstNum = pensionLotteryBaseInfoVo.getPensionFirstNum();
-        pensionSecondNum = pensionLotteryBaseInfoVo.getPensionSecondNum();
-        pensionThirdNum = pensionLotteryBaseInfoVo.getPensionThirdNum();
-        pensionFourthNum = pensionLotteryBaseInfoVo.getPensionFourthNum();
-        pensionFifthNum = pensionLotteryBaseInfoVo.getPensionFifthNum();
-        pensionSixthNum = pensionLotteryBaseInfoVo.getPensionSixthNum();
+    public PensionLotteryNumbersResponse(PensionLotteryBaseInfoVo pensionLotteryBaseInfoVo,List<Boolean> checkNumbers,List<Boolean> checkBonusNumbers) {
+        this.pensionGroup = pensionLotteryBaseInfoVo.getPensionGroup();
+        this.pensionFirstNum = pensionLotteryBaseInfoVo.getPensionFirstNum();
+        this.pensionSecondNum = pensionLotteryBaseInfoVo.getPensionSecondNum();
+        this.pensionThirdNum = pensionLotteryBaseInfoVo.getPensionThirdNum();
+        this.pensionFourthNum = pensionLotteryBaseInfoVo.getPensionFourthNum();
+        this.pensionFifthNum = pensionLotteryBaseInfoVo.getPensionFifthNum();
+        this.pensionSixthNum = pensionLotteryBaseInfoVo.getPensionSixthNum();
+        this.rank = pensionLotteryBaseInfoVo.getRank();
+        this.checkWinningBonus = pensionLotteryBaseInfoVo.getCheckWinningBonus();
+        this.correctNumbers = checkNumbers;
+        this.bonusCorrectNumbers = checkBonusNumbers;
     }
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/presentation/dto/response/PensionLotteryResponse.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/presentation/dto/response/PensionLotteryResponse.java
@@ -1,12 +1,8 @@
 package uttugseuja.lucklotteryserver.domain.pensionlottery.presentation.dto.response;
 
 import lombok.Getter;
-import uttugseuja.lucklotteryserver.domain.WinningPensionlottery.domain.vo.WinningPensionLotteryBaseInfoVo;
 import uttugseuja.lucklotteryserver.domain.WinningPensionlottery.dto.response.WinningPensionLotteryBonusNumbersResponse;
 import uttugseuja.lucklotteryserver.domain.WinningPensionlottery.dto.response.WinningPensionLotteryNumbersResponse;
-import uttugseuja.lucklotteryserver.domain.pensionlottery.domain.vo.PensionLotteryBaseInfoVo;
-import uttugseuja.lucklotteryserver.global.common.Rank;
-
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -15,31 +11,23 @@ public class PensionLotteryResponse {
 
     private Integer round;
     private LocalDateTime winningDate;
-    private Rank rank;
-    private Boolean checkWinningBonus;
-    private PensionLotteryNumbersResponse pensionLotteryNumbersResponse;
+    private List<PensionLotteryNumbersResponse> pensionLotteryNumbersResponse;
     private WinningPensionLotteryNumbersResponse winningLotteryNumbersResponse;
     private WinningPensionLotteryBonusNumbersResponse winningPensionLotteryBonusNumbersResponse;
-    private List<Boolean> correctNumbers;
-    private List<Boolean> bonusCorrectNumbers;
 
-    public PensionLotteryResponse(PensionLotteryNumbersResponse pensionLotteryNumbersResponse,
+    public PensionLotteryResponse(Integer round,
+                                  LocalDateTime winningDate,
+                                  List<PensionLotteryNumbersResponse> pensionLotteryNumbersResponse,
                                   WinningPensionLotteryNumbersResponse winningLotteryNumbersResponse,
-                                  WinningPensionLotteryBonusNumbersResponse winningPensionLotteryBonusNumbersResponse,
-                                  PensionLotteryBaseInfoVo pensionLotteryBaseInfoVo,
-                                  List<Boolean> correctNumbers,
-                                  List<Boolean> bonusCorrectNumbers) {
+                                  WinningPensionLotteryBonusNumbersResponse winningPensionLotteryBonusNumbersResponse
 
-        this.round = pensionLotteryBaseInfoVo.getPensionRound();
-        this.winningDate = pensionLotteryBaseInfoVo.getWinningDate();
-        this.rank = pensionLotteryBaseInfoVo.getRank();
-        this.checkWinningBonus = pensionLotteryBaseInfoVo.getCheckWinningBonus();
+                                  ) {
+
+        this.round = round;
+        this.winningDate = winningDate;
         this.pensionLotteryNumbersResponse = pensionLotteryNumbersResponse;
         this.winningLotteryNumbersResponse = winningLotteryNumbersResponse;
         this.winningPensionLotteryBonusNumbersResponse = winningPensionLotteryBonusNumbersResponse;
-        this.correctNumbers = correctNumbers;
-        this.bonusCorrectNumbers = bonusCorrectNumbers;
-
 
     }
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/service/PensionLotteryService.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/service/PensionLotteryService.java
@@ -30,6 +30,11 @@ public class PensionLotteryService {
     private final WinningPensionLotteryService winningPensionLotteryService;
     private final PensionLotteryRepository pensionLotteryRepository;
 
+    private HashMap<Integer, List<PensionLottery>> makeHashMapByPensionRound(List<PensionLottery> pensionLotteries) {
+        return pensionLotteries.stream()
+                .collect(Collectors.groupingBy(PensionLottery::getPensionRound, HashMap::new, Collectors.toList()));
+    }
+
     private List<PensionLotteryNumbersResponse> makePreviousPensionLotteryNumbers(List<PensionLottery> pensionLotteries,
                                                                                   WinningPensionLottery winningPensionLottery) {
         return pensionLotteries.stream()

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/service/PensionLotteryService.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/service/PensionLotteryService.java
@@ -30,6 +30,27 @@ public class PensionLotteryService {
     private final WinningPensionLotteryService winningPensionLotteryService;
     private final PensionLotteryRepository pensionLotteryRepository;
 
+    private PensionLotteryResponse makePensionResponse(Integer round, List<PensionLottery> pensionLotteries) {
+
+        WinningPensionLottery recentWinningPensionLottery = winningPensionLotteryService.getRecentWinningPensionLottery();
+        Integer pensionRound = recentWinningPensionLottery.getRound();
+
+        if(round <= pensionRound){
+            WinningPensionLottery winningPensionLottery = winningPensionLotteryService.getRecentWinningPensionLotteryByRound(round);
+            List<PensionLotteryNumbersResponse> pensionLotteryNumbersResponses = makePreviousPensionLotteryNumbers(pensionLotteries, winningPensionLottery);
+
+            return getPensionLotteryResponse(round,
+                    winningPensionLottery.getLotteryDrawTime(),
+                    winningPensionLottery,
+                    pensionLotteryNumbersResponses);
+        }
+        List<PensionLotteryNumbersResponse> pensionLotteryNumbersResponses = makeRecentPensionLotteryNumbers(pensionLotteries);
+
+        return getPensionLotteryEmptyResponse(pensionRound+1,
+                recentWinningPensionLottery.getLotteryDrawTime().plusDays(7),
+                pensionLotteryNumbersResponses);
+    }
+
     private HashMap<Integer, List<PensionLottery>> makeHashMapByPensionRound(List<PensionLottery> pensionLotteries) {
         return pensionLotteries.stream()
                 .collect(Collectors.groupingBy(PensionLottery::getPensionRound, HashMap::new, Collectors.toList()));

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/service/PensionLotteryService.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/service/PensionLotteryService.java
@@ -19,6 +19,7 @@ import uttugseuja.lucklotteryserver.global.utils.user.UserUtils;
 
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -28,6 +29,17 @@ public class PensionLotteryService {
     private final UserUtils userUtils;
     private final WinningPensionLotteryService winningPensionLotteryService;
     private final PensionLotteryRepository pensionLotteryRepository;
+
+    private List<PensionLotteryNumbersResponse> makePreviousPensionLotteryNumbers(List<PensionLottery> pensionLotteries,
+                                                                                  WinningPensionLottery winningPensionLottery) {
+        return pensionLotteries.stream()
+                .map(pensionLottery -> {
+                    List<Boolean> correctNumbers = checkCorrectNumbers(pensionLottery, winningPensionLottery);
+                    List<Boolean> correctBonusNumbers = checkBonusCorrectNumbers(pensionLottery, winningPensionLottery);
+                    return new PensionLotteryNumbersResponse(pensionLottery.getPensionLotteryBaseInfoVo(), correctNumbers,correctBonusNumbers);
+                })
+                .collect(Collectors.toList());
+    }
 
     private void updatePensionLottery(PensionLottery pensionLottery) {
 

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/service/PensionLotteryService.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/service/PensionLotteryService.java
@@ -41,6 +41,12 @@ public class PensionLotteryService {
                 .collect(Collectors.toList());
     }
 
+    private List<PensionLotteryNumbersResponse> makeRecentPensionLotteryNumbers(List<PensionLottery> pensionLotteries) {
+        return pensionLotteries.stream()
+                .map(pensionLottery -> new PensionLotteryNumbersResponse(pensionLottery.getPensionLotteryBaseInfoVo(), null, null))
+                .collect(Collectors.toList());
+    }
+
     private void updatePensionLottery(PensionLottery pensionLottery) {
 
             WinningPensionLottery winningPensionLottery = winningPensionLotteryService.getRecentWinningPensionLotteryByRound(pensionLottery.getPensionRound());

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/service/PensionLotteryService.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/service/PensionLotteryService.java
@@ -207,11 +207,6 @@ public class PensionLotteryService {
     public void savePensionLottery(CreatePensionLotteryRequest createPensionLotteryRequest) {
         User user = userUtils.getUserFromSecurityContext();
         WinningPensionLottery winningPensionLottery = winningPensionLotteryService.getRecentWinningPensionLottery();
-
-//        if(createPensionLotteryRequest.getPensionRound() > winningPensionLottery.getRound()+1){
-//            throw OverRoundException.EXCEPTION;
-//        }
-
         PensionLottery pensionLottery = makePensionLottery(createPensionLotteryRequest, user, winningPensionLottery);
         pensionLotteryRepository.save(pensionLottery);
     }
@@ -236,7 +231,7 @@ public class PensionLotteryService {
                 .user(user)
                 .winningDate(winningPensionLottery.getLotteryDrawTime().plusDays(7))
                 .checkWinningBonus(false)
-                .pensionRound(createPensionLotteryRequest.getPensionRound())
+                .pensionRound(winningPensionLottery.getRound()+1)
                 .pensionGroup(createPensionLotteryRequest.getPensionGroup())
                 .pensionFirstNum(createPensionLotteryRequest.getPensionFirstNum())
                 .pensionSecondNum(createPensionLotteryRequest.getPensionSecondNum())

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/service/PensionLotteryService.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/service/PensionLotteryService.java
@@ -4,14 +4,20 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uttugseuja.lucklotteryserver.domain.WinningPensionlottery.domain.WinningPensionLottery;
+import uttugseuja.lucklotteryserver.domain.WinningPensionlottery.dto.response.WinningPensionLotteryBonusNumbersResponse;
+import uttugseuja.lucklotteryserver.domain.WinningPensionlottery.dto.response.WinningPensionLotteryNumbersResponse;
 import uttugseuja.lucklotteryserver.domain.WinningPensionlottery.service.WinningPensionLotteryService;
 import uttugseuja.lucklotteryserver.domain.pensionlottery.domain.PensionLottery;
 import uttugseuja.lucklotteryserver.domain.pensionlottery.domain.repository.PensionLotteryRepository;
 import uttugseuja.lucklotteryserver.domain.pensionlottery.presentation.dto.request.CreatePensionLotteryRequest;
+import uttugseuja.lucklotteryserver.domain.pensionlottery.presentation.dto.response.PensionLotteryNumbersResponse;
+import uttugseuja.lucklotteryserver.domain.pensionlottery.presentation.dto.response.PensionLotteryResponse;
 import uttugseuja.lucklotteryserver.domain.pensionlottery.presentation.dto.response.RandomPensionLotteryResponse;
 import uttugseuja.lucklotteryserver.domain.user.domain.User;
 import uttugseuja.lucklotteryserver.global.common.Rank;
 import uttugseuja.lucklotteryserver.global.utils.user.UserUtils;
+
+import java.time.LocalDateTime;
 import java.util.*;
 
 @Service
@@ -37,7 +43,35 @@ public class PensionLotteryService {
             updateCorrectBonus(correctBonusCount,pensionLottery);
     }
 
+    private PensionLotteryResponse getPensionLotteryResponse(Integer round,
+                                                             LocalDateTime winningDate,
+                                                             WinningPensionLottery winningPensionLottery,
+                                                             List<PensionLotteryNumbersResponse> pensionLotteryNumbersResponseList) {
 
+        WinningPensionLotteryNumbersResponse winningPensionNumbersResponse = new WinningPensionLotteryNumbersResponse(winningPensionLottery.getWinningPensionLotteryBaseInfoVo());
+        WinningPensionLotteryBonusNumbersResponse winningPensionLotteryBonusNumbersResponse = new WinningPensionLotteryBonusNumbersResponse(winningPensionLottery.getWinningPensionLotteryBaseInfoVo());
+
+        return new PensionLotteryResponse(
+                round,
+                winningDate,
+                pensionLotteryNumbersResponseList,
+                winningPensionNumbersResponse,
+                winningPensionLotteryBonusNumbersResponse
+        );
+    }
+
+    private PensionLotteryResponse getPensionLotteryEmptyResponse(Integer round,
+                                                                  LocalDateTime winningDate,
+                                                                  List<PensionLotteryNumbersResponse> pensionLotteryNumbersResponseList) {
+
+        return new PensionLotteryResponse(
+                round,
+                winningDate,
+                pensionLotteryNumbersResponseList,
+                null,
+                null
+        );
+    }
 
     private Rank getPensionLotteryResult(Integer count){
 


### PR DESCRIPTION
resolved: #94 
## 작업내용
- 연금 복권 모두  조회 ->  회차별로 조회
- In 쿼리를 통해  회차를 기준으로 모든 연급복권 엔티티를 가져오도록 변경
- 페이징 처리
