### PR TITLE
fix : 연급 복권 시간 관련 기능 수정

### DIFF
--- a/src/main/java/uttugseuja/lucklotteryserver/domain/WinningPensionlottery/domain/WinningPensionLottery.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/WinningPensionlottery/domain/WinningPensionLottery.java
@@ -8,7 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import uttugseuja.lucklotteryserver.domain.WinningPensionlottery.domain.vo.WinningPensionLotteryBaseInfoVo;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import static jakarta.persistence.GenerationType.IDENTITY;
@@ -25,7 +25,7 @@ public class WinningPensionLottery {
     private Long id;
 
     private Integer round;
-    private LocalDateTime lotteryDrawTime;
+    private LocalDate lotteryDrawTime;
     private Integer lotteryGroup;
     private Integer winningFirstNum;
     private Integer winningSecondNum;
@@ -43,7 +43,7 @@ public class WinningPensionLottery {
     @Builder
     public WinningPensionLottery(Long id,
                                  Integer round,
-                                 LocalDateTime lotteryDrawTime,
+                                 LocalDate lotteryDrawTime,
                                  Integer lotteryGroup,
                                  Integer winningFirstNum,
                                  Integer winningSecondNum,

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/WinningPensionlottery/domain/repository/WinningPensionLotteryJdbcRepository.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/WinningPensionlottery/domain/repository/WinningPensionLotteryJdbcRepository.java
@@ -29,7 +29,7 @@ public class WinningPensionLotteryJdbcRepository {
             @Override
             public void setValues(PreparedStatement ps, int i) throws SQLException {
                 WinningPensionLottery pensionLottery = pensionLotteryList.get(i);
-                Timestamp timestamp = Timestamp.valueOf(pensionLottery.getLotteryDrawTime());
+                Timestamp timestamp = Timestamp.valueOf(pensionLottery.getLotteryDrawTime().atStartOfDay());
                 ps.setInt(1,pensionLottery.getRound());
                 ps.setTimestamp(2,timestamp);
                 ps.setInt(3,pensionLottery.getLotteryGroup());

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/WinningPensionlottery/domain/vo/WinningPensionLotteryBaseInfoVo.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/WinningPensionlottery/domain/vo/WinningPensionLotteryBaseInfoVo.java
@@ -2,7 +2,7 @@ package uttugseuja.lucklotteryserver.domain.WinningPensionlottery.domain.vo;
 
 import lombok.Builder;
 import lombok.Getter;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Getter
 @Builder
@@ -10,7 +10,7 @@ public class WinningPensionLotteryBaseInfoVo {
 
     private Long winningPensionLotteryId;
     private Integer round;
-    private LocalDateTime lotteryDrawTime;
+    private LocalDate lotteryDrawTime;
     private Integer lotteryGroup;
     private Integer winningFirstNum;
     private Integer winningSecondNum;

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/WinningPensionlottery/dto/request/LotteryDrawDayDto.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/WinningPensionlottery/dto/request/LotteryDrawDayDto.java
@@ -3,17 +3,13 @@ package uttugseuja.lucklotteryserver.domain.WinningPensionlottery.dto.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-
-
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @AllArgsConstructor
 @Getter
 public class LotteryDrawDayDto {
 
     private Integer round;
-    private LocalDateTime lotteryDrawTime;
-
-
+    private LocalDate lotteryDrawTime;
 
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/WinningPensionlottery/dto/request/WinningPensionLotteryCrawlingDto.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/WinningPensionlottery/dto/request/WinningPensionLotteryCrawlingDto.java
@@ -2,8 +2,7 @@ package uttugseuja.lucklotteryserver.domain.WinningPensionlottery.dto.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 @Getter
@@ -11,7 +10,7 @@ import java.util.List;
 public class WinningPensionLotteryCrawlingDto {
 
     private Integer pensionLotteryRound;
-    private LocalDateTime lotteryDrawTime;
+    private LocalDate lotteryDrawTime;
     private List<Integer> winningNumbers;
 
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/WinningPensionlottery/dto/response/WinningPensionLotteryResponse.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/WinningPensionlottery/dto/response/WinningPensionLotteryResponse.java
@@ -2,14 +2,14 @@ package uttugseuja.lucklotteryserver.domain.WinningPensionlottery.dto.response;
 
 import lombok.Getter;
 import uttugseuja.lucklotteryserver.domain.WinningPensionlottery.domain.vo.WinningPensionLotteryBaseInfoVo;
+import java.time.LocalDate;
 
-import java.time.LocalDateTime;
 
 @Getter
 public class WinningPensionLotteryResponse {
 
     private Integer round;
-    private LocalDateTime winningDate;
+    private LocalDate winningDate;
     private Integer lotteryGroup;
     private Integer winningFirstNum;
     private Integer winningSecondNum;

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/WinningPensionlottery/service/WinningPensionLotteryService.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/WinningPensionlottery/service/WinningPensionLotteryService.java
@@ -21,7 +21,7 @@ import uttugseuja.lucklotteryserver.domain.WinningPensionlottery.exception.PageA
 import uttugseuja.lucklotteryserver.domain.WinningPensionlottery.exception.WinningPensionLotteryNotFoundException;
 import uttugseuja.lucklotteryserver.global.error.exception.LuckLotteryIoException;
 import java.io.IOException;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -147,17 +147,14 @@ public class WinningPensionLotteryService implements WinningPensionLotteryUtils{
 
         Pattern pattern = Pattern.compile("\\d+");
         Matcher matcher = pattern.matcher(dayAndRound);
-
         List<Integer> parsedData = new ArrayList<>();
 
         while (matcher.find()) {
             parsedData.add(Integer.parseInt(matcher.group()));
         }
 
-        LocalDateTime drawDay = LocalDateTime.of(parsedData.get(1), parsedData.get(2), parsedData.get(3), 17,0);
-
+        LocalDate drawDay = LocalDate.of(parsedData.get(1), parsedData.get(2), parsedData.get(3));
         Integer drawRound = parsedData.get(0);
-
         return new LotteryDrawDayDto(drawRound,drawDay);
     }
 

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/domain/PensionLottery.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/domain/PensionLottery.java
@@ -4,16 +4,13 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import uttugseuja.lucklotteryserver.domain.lottery.domain.vo.LotteryBaseInfoVo;
 import uttugseuja.lucklotteryserver.domain.pensionlottery.domain.vo.PensionLotteryBaseInfoVo;
 import uttugseuja.lucklotteryserver.domain.user.domain.User;
 import uttugseuja.lucklotteryserver.global.common.Rank;
 import uttugseuja.lucklotteryserver.global.database.BaseEntity;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
@@ -35,7 +32,7 @@ public class PensionLottery extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Rank rank;
 
-    private LocalDateTime winningDate;
+    private LocalDate winningDate;
     private Boolean checkWinningBonus;
     private Integer pensionRound;
     private Integer pensionGroup;
@@ -53,7 +50,7 @@ public class PensionLottery extends BaseEntity {
                    Rank rank,
                    Boolean checkWinningBonus,
                    Integer pensionRound,
-                   LocalDateTime winningDate,
+                   LocalDate winningDate,
                    Integer pensionGroup,
                    Integer pensionFirstNum,
                    Integer pensionSecondNum,

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/domain/vo/PensionLotteryBaseInfoVo.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/domain/vo/PensionLotteryBaseInfoVo.java
@@ -3,6 +3,7 @@ package uttugseuja.lucklotteryserver.domain.pensionlottery.domain.vo;
 import lombok.Builder;
 import lombok.Getter;
 import uttugseuja.lucklotteryserver.global.common.Rank;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
@@ -12,7 +13,7 @@ public class PensionLotteryBaseInfoVo {
     private final Long pensionLotteryId;
     private Boolean checkWinningBonus;
     private final Integer pensionRound;
-    private final LocalDateTime winningDate;
+    private final LocalDate winningDate;
     private final Integer pensionGroup;
     private final Integer pensionFirstNum;
     private final Integer pensionSecondNum;

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/presentation/dto/response/PensionLotteryResponse.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/presentation/dto/response/PensionLotteryResponse.java
@@ -3,20 +3,20 @@ package uttugseuja.lucklotteryserver.domain.pensionlottery.presentation.dto.resp
 import lombok.Getter;
 import uttugseuja.lucklotteryserver.domain.WinningPensionlottery.dto.response.WinningPensionLotteryBonusNumbersResponse;
 import uttugseuja.lucklotteryserver.domain.WinningPensionlottery.dto.response.WinningPensionLotteryNumbersResponse;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 @Getter
 public class PensionLotteryResponse {
 
     private Integer round;
-    private LocalDateTime winningDate;
+    private LocalDate winningDate;
     private List<PensionLotteryNumbersResponse> pensionLotteryNumbersResponse;
     private WinningPensionLotteryNumbersResponse winningLotteryNumbersResponse;
     private WinningPensionLotteryBonusNumbersResponse winningPensionLotteryBonusNumbersResponse;
 
     public PensionLotteryResponse(Integer round,
-                                  LocalDateTime winningDate,
+                                  LocalDate winningDate,
                                   List<PensionLotteryNumbersResponse> pensionLotteryNumbersResponse,
                                   WinningPensionLotteryNumbersResponse winningLotteryNumbersResponse,
                                   WinningPensionLotteryBonusNumbersResponse winningPensionLotteryBonusNumbersResponse

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/service/PensionLotteryService.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/pensionlottery/service/PensionLotteryService.java
@@ -19,7 +19,7 @@ import uttugseuja.lucklotteryserver.domain.pensionlottery.presentation.dto.respo
 import uttugseuja.lucklotteryserver.domain.user.domain.User;
 import uttugseuja.lucklotteryserver.global.common.Rank;
 import uttugseuja.lucklotteryserver.global.utils.user.UserUtils;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -107,7 +107,7 @@ public class PensionLotteryService {
     }
 
     private PensionLotteryResponse getPensionLotteryResponse(Integer round,
-                                                             LocalDateTime winningDate,
+                                                             LocalDate winningDate,
                                                              WinningPensionLottery winningPensionLottery,
                                                              List<PensionLotteryNumbersResponse> pensionLotteryNumbersResponseList) {
 
@@ -124,7 +124,7 @@ public class PensionLotteryService {
     }
 
     private PensionLotteryResponse getPensionLotteryEmptyResponse(Integer round,
-                                                                  LocalDateTime winningDate,
+                                                                  LocalDate winningDate,
                                                                   List<PensionLotteryNumbersResponse> pensionLotteryNumbersResponseList) {
 
         return new PensionLotteryResponse(


### PR DESCRIPTION
resolved: #105 
## 작업내용
- 연금 복권 엔티티 추첨 날짜 수정 
- 크롤링 할 연금 복권 당첨 번호 날짜 수정
- 당첨 연금 복권 날짜를 LocalDateTime  -> LocalDate로 수정 



