### PR TITLE
feat : 회원 탈퇴기능 구현 및 유저정보 제공 기능 구현 

### DIFF
--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/presentation/CredentialController.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/presentation/CredentialController.java
@@ -49,7 +49,7 @@ public class CredentialController {
     @GetMapping("/oauth/kakao")
     public AfterOauthResponse kakaoAuth(OauthCodeRequest oauthCodeRequest) {
         log.info("code = {}",oauthCodeRequest.getCode());
-        return credentialService.getIdTokenToCode(OauthProvider.KAKAO, oauthCodeRequest.getCode());
+        return credentialService.getTokenToCode(OauthProvider.KAKAO, oauthCodeRequest.getCode());
     }
 
     @Operation(summary = "구글 로그인 링크 받기 테스트용")
@@ -62,7 +62,7 @@ public class CredentialController {
     @GetMapping("/oauth/google")
     public AfterOauthResponse googleAuth(OauthCodeRequest oauthCodeRequest) {
         log.info("code = {}",oauthCodeRequest.getCode());
-        return credentialService.getIdTokenToCode(OauthProvider.GOOGLE, oauthCodeRequest.getCode());
+        return credentialService.getTokenToCode(OauthProvider.GOOGLE, oauthCodeRequest.getCode());
     }
 
     @Operation(summary = "Id Token 검증")

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/presentation/CredentialController.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/presentation/CredentialController.java
@@ -116,4 +116,10 @@ public class CredentialController {
         credentialService.logoutUser();
     }
 
+    @Operation(summary = "회원 탈퇴기능 입니다.  카카오,구글 oauth 연결도 unlink 합니다. ")
+    @DeleteMapping("/delete/me")
+    public void deleteUser(@RequestParam(value = "oauth_access_token", required = false) String token) {
+        credentialService.deleteUser(token);
+    }
+
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/presentation/dto/response/AfterOauthResponse.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/presentation/dto/response/AfterOauthResponse.java
@@ -8,4 +8,5 @@ import lombok.Getter;
 @AllArgsConstructor
 public class AfterOauthResponse {
     private String idToken;
+    private String accessToken;
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/presentation/dto/response/OauthTokenInfoDto.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/presentation/dto/response/OauthTokenInfoDto.java
@@ -1,0 +1,11 @@
+package uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OauthTokenInfoDto {
+    private String idToken;
+    private String accessToken;
+}

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/CredentialService.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/CredentialService.java
@@ -8,23 +8,16 @@ import uttugseuja.lucklotteryserver.domain.credential.domain.RefreshTokenRedisEn
 import uttugseuja.lucklotteryserver.domain.credential.domain.repository.RefreshTokenRedisEntityRepository;
 import uttugseuja.lucklotteryserver.domain.credential.exception.RefreshTokenExpiredException;
 import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.request.RegisterRequest;
-import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response.AccessTokenDto;
-import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response.AfterOauthResponse;
-import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response.AuthTokensResponse;
-import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response.CheckRegisteredResponse;
+import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response.*;
 import uttugseuja.lucklotteryserver.domain.user.domain.User;
 import uttugseuja.lucklotteryserver.domain.user.domain.repository.UserRepository;
+import uttugseuja.lucklotteryserver.global.api.dto.UserInfoToOauthDto;
 import uttugseuja.lucklotteryserver.global.exception.InvalidTokenException;
 import uttugseuja.lucklotteryserver.global.exception.UserNotFoundException;
 import uttugseuja.lucklotteryserver.global.security.JwtTokenProvider;
 import uttugseuja.lucklotteryserver.global.utils.user.UserUtils;
-
-
-import java.security.NoSuchAlgorithmException;
-import java.security.spec.InvalidKeySpecException;
 import java.util.Optional;
 import java.util.UUID;
-
 
 @Service
 @AllArgsConstructor
@@ -66,15 +59,13 @@ public class CredentialService {
     }
 
     @Transactional
-    public AfterOauthResponse getIdTokenToCode(OauthProvider oauthProvider, String code) {
+    public AfterOauthResponse getTokenToCode(OauthProvider oauthProvider, String code) {
         OauthStrategy oauthStrategy = oauthFactory.getOauthstrategy(oauthProvider);
-        log.info("oauthStrategy ={}" ,oauthStrategy);
-        String idToken = oauthStrategy.getIdToken(code);
-        log.info("idToken ={}" ,idToken);
-        return new AfterOauthResponse(idToken);
+        OauthTokenInfoDto oauthToken = oauthStrategy.getOauthToken(code);
+        return new AfterOauthResponse(oauthToken.getIdToken(),oauthToken.getAccessToken());
     }
 
-    public CheckRegisteredResponse getUserAvailableRegister(String token, OauthProvider oauthProvider) throws NoSuchAlgorithmException, InvalidKeySpecException {
+    public CheckRegisteredResponse getUserAvailableRegister(String token, OauthProvider oauthProvider) {
         OauthStrategy oauthstrategy = oauthFactory.getOauthstrategy(oauthProvider);
         OIDCDecodePayload oidcDecodePayload = oauthstrategy.getOIDCDecodePayload(token);
         Boolean isRegistered = !checkUserCanRegister(oidcDecodePayload, oauthProvider);
@@ -94,7 +85,7 @@ public class CredentialService {
         return user.isEmpty();
     }
 
-    public AuthTokensResponse loginUserByOCIDToken(String token, OauthProvider oauthProvider) throws NoSuchAlgorithmException, InvalidKeySpecException {
+    public AuthTokensResponse loginUserByOCIDToken(String token, OauthProvider oauthProvider) {
         OauthStrategy oauthStrategy = oauthFactory.getOauthstrategy(oauthProvider);
         OIDCDecodePayload oidcDecodePayload = oauthStrategy.getOIDCDecodePayload(token);
 
@@ -117,7 +108,7 @@ public class CredentialService {
 
     @Transactional
     public AuthTokensResponse registerUserByOCIDToken(
-            String token, RegisterRequest registerUserRequest, OauthProvider oauthProvider) throws NoSuchAlgorithmException, InvalidKeySpecException {
+            String token, RegisterRequest registerUserRequest, OauthProvider oauthProvider) {
         OauthStrategy oauthStrategy = oauthFactory.getOauthstrategy(oauthProvider);
         OIDCDecodePayload oidcDecodePayload = oauthStrategy.getOIDCDecodePayload(token);
 
@@ -180,8 +171,6 @@ public class CredentialService {
         refreshTokenRedisEntityRepository.save(build);
         return refreshToken;
     }
-
-
 
 }
 

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/GoogleOauthStrategy.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/GoogleOauthStrategy.java
@@ -2,10 +2,11 @@ package uttugseuja.lucklotteryserver.domain.credential.service;
 
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
+import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response.OauthTokenInfoDto;
 import uttugseuja.lucklotteryserver.global.api.client.GoogleAuthClient;
 import uttugseuja.lucklotteryserver.global.api.dto.OIDCKeysResponse;
+import uttugseuja.lucklotteryserver.global.api.dto.OauthTokenResponse;
 import uttugseuja.lucklotteryserver.global.property.OauthProperties;
-
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 
@@ -40,16 +41,19 @@ public class GoogleOauthStrategy implements OauthStrategy{
     }
 
     @Override
-    public String getIdToken(String code) {
+    public OauthTokenInfoDto getOauthToken(String code) {
         String decodedCode = URLDecoder.decode(code, StandardCharsets.UTF_8);
 
-        return googleAuthClient
+        OauthTokenResponse oauthTokenResponse = googleAuthClient
                 .googleAuth(
                         oauthProperties.getGoogleAppId(),
                         oauthProperties.getGoogleRedirectUrl(),
                         decodedCode,
-                        oauthProperties.getGoogleClientSecret())
-                .getIdToken();
+                        oauthProperties.getGoogleClientSecret());
+       return OauthTokenInfoDto.builder()
+               .idToken(oauthTokenResponse.getIdToken())
+               .accessToken(oauthTokenResponse.getAccessToken())
+               .build();
 
     }
 

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/GoogleOauthStrategy.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/GoogleOauthStrategy.java
@@ -6,6 +6,7 @@ import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response.
 import uttugseuja.lucklotteryserver.global.api.client.GoogleAuthClient;
 import uttugseuja.lucklotteryserver.global.api.dto.OIDCKeysResponse;
 import uttugseuja.lucklotteryserver.global.api.dto.OauthTokenResponse;
+import uttugseuja.lucklotteryserver.global.api.dto.UserInfoToOauthDto;
 import uttugseuja.lucklotteryserver.global.property.OauthProperties;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -18,6 +19,7 @@ public class GoogleOauthStrategy implements OauthStrategy{
     private final OauthProperties oauthProperties;
     private final GoogleAuthClient googleAuthClient;
     private final OauthOIDCProvider oauthOIDCProvider;
+    private static final String PREFIX = "Bearer ";
     private static final String ISSUER = "https://accounts.google.com";
     private static final String QUERY_STRING =
             "/o/oauth2/v2/auth?client_id=%s&redirect_uri=%s&response_type=code&scope=%s";
@@ -55,6 +57,11 @@ public class GoogleOauthStrategy implements OauthStrategy{
                .accessToken(oauthTokenResponse.getAccessToken())
                .build();
 
+    }
+
+    @Override
+    public UserInfoToOauthDto getUserInfo(String accessToken){
+         return googleAuthClient.getGoogleInfo(PREFIX + accessToken);
     }
 
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/GoogleOauthStrategy.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/GoogleOauthStrategy.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
 import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response.OauthTokenInfoDto;
 import uttugseuja.lucklotteryserver.global.api.client.GoogleAuthClient;
+import uttugseuja.lucklotteryserver.global.api.client.GoogleUnlinkClient;
 import uttugseuja.lucklotteryserver.global.api.dto.OIDCKeysResponse;
 import uttugseuja.lucklotteryserver.global.api.dto.OauthTokenResponse;
 import uttugseuja.lucklotteryserver.global.api.dto.UserInfoToOauthDto;
@@ -19,6 +20,7 @@ public class GoogleOauthStrategy implements OauthStrategy{
     private final OauthProperties oauthProperties;
     private final GoogleAuthClient googleAuthClient;
     private final OauthOIDCProvider oauthOIDCProvider;
+    private final GoogleUnlinkClient googleUnlinkClient;
     private static final String PREFIX = "Bearer ";
     private static final String ISSUER = "https://accounts.google.com";
     private static final String QUERY_STRING =
@@ -62,6 +64,11 @@ public class GoogleOauthStrategy implements OauthStrategy{
     @Override
     public UserInfoToOauthDto getUserInfo(String accessToken){
          return googleAuthClient.getGoogleInfo(PREFIX + accessToken);
+    }
+
+    @Override
+    public void unLink(String oauthAccessToken) {
+        googleUnlinkClient.unlink(oauthAccessToken);
     }
 
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/KaKaoOauthStrategy.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/KaKaoOauthStrategy.java
@@ -19,6 +19,9 @@ public class KaKaoOauthStrategy implements OauthStrategy {
     private final OauthProperties oauthProperties;
     private final KakaoOauthClient kakaoOauthClient;
     private final OauthOIDCProvider oauthOIDCProvider;
+    private final KakaoUnlinkClient kakaoUnlinkClient;
+    private static final String PREFIX = "KakaoAK ";
+    private static final String TARGET_TYPE = "user_id";
     private static final String ISSUER = "https://kauth.kakao.com";
     private static final String QUERY_STRING = "/oauth/authorize?client_id=%s&redirect_uri=%s&response_type=code";
 
@@ -56,6 +59,11 @@ public class KaKaoOauthStrategy implements OauthStrategy {
         return null;
     }
 
+    @Override
+    public void unLink(String userOauthId) {
+        String kakaoAdminKey = oauthProperties.getKakaoAdminKey();
+        kakaoUnlinkClient.unlinkUser(PREFIX + kakaoAdminKey,TARGET_TYPE, Long.valueOf(userOauthId));
+    }
 
 
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/KaKaoOauthStrategy.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/KaKaoOauthStrategy.java
@@ -5,8 +5,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response.OauthTokenInfoDto;
 import uttugseuja.lucklotteryserver.global.api.client.KakaoOauthClient;
+import uttugseuja.lucklotteryserver.global.api.client.KakaoUnlinkClient;
 import uttugseuja.lucklotteryserver.global.api.dto.OIDCKeysResponse;
 import uttugseuja.lucklotteryserver.global.api.dto.OauthTokenResponse;
+import uttugseuja.lucklotteryserver.global.api.dto.UserInfoToOauthDto;
 import uttugseuja.lucklotteryserver.global.property.OauthProperties;
 
 @AllArgsConstructor
@@ -48,5 +50,12 @@ public class KaKaoOauthStrategy implements OauthStrategy {
                 .accessToken(oauthTokenResponse.getAccessToken())
                 .build();
     }
+
+    @Override
+    public UserInfoToOauthDto getUserInfo(String oauthAccessToken) {
+        return null;
+    }
+
+
 
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/KaKaoOauthStrategy.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/KaKaoOauthStrategy.java
@@ -3,12 +3,11 @@ package uttugseuja.lucklotteryserver.domain.credential.service;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response.OauthTokenInfoDto;
 import uttugseuja.lucklotteryserver.global.api.client.KakaoOauthClient;
 import uttugseuja.lucklotteryserver.global.api.dto.OIDCKeysResponse;
+import uttugseuja.lucklotteryserver.global.api.dto.OauthTokenResponse;
 import uttugseuja.lucklotteryserver.global.property.OauthProperties;
-
-
-
 
 @AllArgsConstructor
 @Component("KAKAO")
@@ -38,12 +37,16 @@ public class KaKaoOauthStrategy implements OauthStrategy {
     }
 
     @Override
-    public String getIdToken(String code) {
-        return kakaoOauthClient
+    public OauthTokenInfoDto getOauthToken(String code) {
+        OauthTokenResponse oauthTokenResponse = kakaoOauthClient
                 .kakaoAuth(
                         oauthProperties.getKakaoClientId(),
                         oauthProperties.getKakaoRedirectUrl(),
-                        code)
-                .getIdToken();
+                        code);
+        return OauthTokenInfoDto.builder()
+                .idToken(oauthTokenResponse.getIdToken())
+                .accessToken(oauthTokenResponse.getAccessToken())
+                .build();
     }
+
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/OauthStrategy.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/OauthStrategy.java
@@ -11,4 +11,6 @@ public interface OauthStrategy {
     OauthTokenInfoDto getOauthToken(String code);
 
     UserInfoToOauthDto getUserInfo(String oauthAccessToken);
+
+    void unLink(String oauthAccessToken);
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/OauthStrategy.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/OauthStrategy.java
@@ -1,12 +1,11 @@
 package uttugseuja.lucklotteryserver.domain.credential.service;
 
-import java.security.NoSuchAlgorithmException;
-import java.security.spec.InvalidKeySpecException;
+import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response.OauthTokenInfoDto;
 
 public interface OauthStrategy {
     OIDCDecodePayload getOIDCDecodePayload(String token);
 
     String getOauthLink();
 
-    String getIdToken(String code);
+    OauthTokenInfoDto getOauthToken(String code);
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/OauthStrategy.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/OauthStrategy.java
@@ -1,6 +1,7 @@
 package uttugseuja.lucklotteryserver.domain.credential.service;
 
 import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response.OauthTokenInfoDto;
+import uttugseuja.lucklotteryserver.global.api.dto.UserInfoToOauthDto;
 
 public interface OauthStrategy {
     OIDCDecodePayload getOIDCDecodePayload(String token);
@@ -8,4 +9,6 @@ public interface OauthStrategy {
     String getOauthLink();
 
     OauthTokenInfoDto getOauthToken(String code);
+
+    UserInfoToOauthDto getUserInfo(String oauthAccessToken);
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/user/domain/User.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/user/domain/User.java
@@ -7,9 +7,11 @@ import lombok.NoArgsConstructor;
 import org.springframework.lang.Nullable;
 import uttugseuja.lucklotteryserver.domain.credential.event.LogoutUserEvent;
 import uttugseuja.lucklotteryserver.domain.notification.event.DeviceTokenEvent;
+import uttugseuja.lucklotteryserver.domain.pensionlottery.domain.PensionLottery;
 import uttugseuja.lucklotteryserver.domain.user.domain.vo.UserInfoVO;
 import uttugseuja.lucklotteryserver.global.event.Events;
-
+import java.util.ArrayList;
+import java.util.List;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -62,6 +64,7 @@ public class User {
     public UserInfoVO getUserInfo() {
         return UserInfoVO.builder()
                 .userId(id)
+                .oauthProvider(oauthProvider)
                 .nickname(nickname)
                 .email(email)
                 .profilePath(profilePath)

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/user/domain/User.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/user/domain/User.java
@@ -25,6 +25,9 @@ public class User {
     @Column(name = "user_id")
     private Long id;
 
+    @OneToMany(mappedBy = "user",cascade = CascadeType.ALL)
+    private List<PensionLottery> pensionLotteries = new ArrayList<>();
+
     private String nickname;
 
     private String oauthProvider;

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/user/domain/vo/UserInfoVO.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/user/domain/vo/UserInfoVO.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Builder
 public class UserInfoVO {
     private final Long userId;
+    private final String oauthProvider;
     private final String nickname;
     private final String email;
     private final String profilePath;

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/user/presentation/UserController.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/user/presentation/UserController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.*;
 import uttugseuja.lucklotteryserver.domain.user.presentation.dto.request.ChangeNicknameRequest;
 import uttugseuja.lucklotteryserver.domain.user.presentation.dto.request.ChangeNotificationStatusRequest;
 import uttugseuja.lucklotteryserver.domain.user.presentation.dto.request.ChangeProfileRequest;
-import uttugseuja.lucklotteryserver.domain.user.presentation.dto.response.UserNotificationStateResponse;
+import uttugseuja.lucklotteryserver.domain.user.presentation.dto.response.UserInfoResponse;
 import uttugseuja.lucklotteryserver.domain.user.presentation.dto.response.UserProfileResponse;
 import uttugseuja.lucklotteryserver.domain.user.service.UserService;
 
@@ -47,9 +47,9 @@ public class UserController {
         userService.changePensionLotteryNotificationStatus(changeNotificationStatusRequest);
     }
 
-    @Operation(summary = "유저 알림 상태 정보")
-    @GetMapping("/notification/state")
-    public UserNotificationStateResponse getUserNotificationState() {
-        return userService.getUserNotificationState();
+    @Operation(summary = "유저 장보 가져오기")
+    @GetMapping("/my/info")
+    public UserInfoResponse getUserInfo(){
+        return userService.getUserInfo();
     }
  }

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/user/presentation/dto/response/UserInfoResponse.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/user/presentation/dto/response/UserInfoResponse.java
@@ -1,0 +1,28 @@
+package uttugseuja.lucklotteryserver.domain.user.presentation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import uttugseuja.lucklotteryserver.domain.user.domain.vo.UserInfoVO;
+
+@Getter
+@AllArgsConstructor
+public class UserInfoResponse {
+
+    private Long id;
+    private String nickname;
+    private String oauthProvider;
+    private String email;
+    private String profilePath;
+    private Boolean lotteryNotificationStatus;
+    private Boolean pensionLotteryNotificationStatus;
+
+    public UserInfoResponse(UserInfoVO userInfoVO){
+        this.id = userInfoVO.getUserId();
+        this.nickname = userInfoVO.getNickname();
+        this.oauthProvider = userInfoVO.getOauthProvider();
+        this.email = userInfoVO.getEmail();
+        this.profilePath = userInfoVO.getProfilePath();
+        this.lotteryNotificationStatus = userInfoVO.getLotteryNotificationStatus();
+        this.pensionLotteryNotificationStatus = userInfoVO.getPensionLotteryNotificationStatus();
+    }
+}

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/user/service/UserService.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/user/service/UserService.java
@@ -9,7 +9,7 @@ import uttugseuja.lucklotteryserver.domain.user.domain.User;
 import uttugseuja.lucklotteryserver.domain.user.presentation.dto.request.ChangeNicknameRequest;
 import uttugseuja.lucklotteryserver.domain.user.presentation.dto.request.ChangeNotificationStatusRequest;
 import uttugseuja.lucklotteryserver.domain.user.presentation.dto.request.ChangeProfileRequest;
-import uttugseuja.lucklotteryserver.domain.user.presentation.dto.response.UserNotificationStateResponse;
+import uttugseuja.lucklotteryserver.domain.user.presentation.dto.response.UserInfoResponse;
 import uttugseuja.lucklotteryserver.domain.user.presentation.dto.response.UserProfileResponse;
 import uttugseuja.lucklotteryserver.global.utils.user.UserUtils;
 
@@ -61,9 +61,8 @@ public class UserService {
 
     }
 
-    public UserNotificationStateResponse getUserNotificationState() {
+    public UserInfoResponse getUserInfo() {
         User user = userUtils.getUserFromSecurityContext();
-
-        return new UserNotificationStateResponse(user.getUserInfo());
+        return new UserInfoResponse(user.getUserInfo());
     }
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/global/api/client/GoogleAuthClient.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/global/api/client/GoogleAuthClient.java
@@ -6,8 +6,10 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import uttugseuja.lucklotteryserver.global.api.dto.UserInfoToOauthDto;
 import uttugseuja.lucklotteryserver.global.api.dto.OIDCKeysResponse;
-import uttugseuja.lucklotteryserver.global.api.dto.OauthIdTokenResponse;
+import uttugseuja.lucklotteryserver.global.api.dto.OauthTokenResponse;
 
 @FeignClient(name = "GoogleAuthClient", url = "https://www.googleapis.com/oauth2")
 public interface GoogleAuthClient {
@@ -15,7 +17,7 @@ public interface GoogleAuthClient {
     @Headers("Content-type: application/x-www-form-urlencoded;charset=utf-8")
     @PostMapping(
             "/v4/token?grant_type=authorization_code&client_id={CLIENT_ID}&redirect_uri={REDIRECT_URI}&code={CODE}&client_secret={CLIENT_SECRET}")
-    OauthIdTokenResponse googleAuth(
+    OauthTokenResponse googleAuth(
             @PathVariable("CLIENT_ID") String clientId,
             @PathVariable("REDIRECT_URI") String redirectUri,
             @PathVariable("CODE") String code,
@@ -24,5 +26,9 @@ public interface GoogleAuthClient {
     @Cacheable(cacheNames = "GoogleOICD", cacheManager = "oidcKeyCacheManager")
     @GetMapping("/v3/certs")
     OIDCKeysResponse getGoogleOIDCOpenKeys();
+
+    @GetMapping("/v1/userinfo?alt=json")
+    UserInfoToOauthDto getGoogleInfo(@RequestHeader("Authorization") String token);
+
 }
 

--- a/src/main/java/uttugseuja/lucklotteryserver/global/api/client/GoogleUnlinkClient.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/global/api/client/GoogleUnlinkClient.java
@@ -1,0 +1,14 @@
+package uttugseuja.lucklotteryserver.global.api.client;
+
+import feign.Headers;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "GoogleUnlinkClient", url = "https://oauth2.googleapis.com/revoke")
+public interface GoogleUnlinkClient {
+
+    @PostMapping
+    @Headers("Content-type:application/x-www-form-urlencoded")
+    void unlink(@RequestParam("token") String oauthAccessToken);
+}

--- a/src/main/java/uttugseuja/lucklotteryserver/global/api/client/KakaoOauthClient.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/global/api/client/KakaoOauthClient.java
@@ -1,6 +1,5 @@
 package uttugseuja.lucklotteryserver.global.api.client;
 
-
 import feign.Headers;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -8,7 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import uttugseuja.lucklotteryserver.global.api.dto.OIDCKeysResponse;
-import uttugseuja.lucklotteryserver.global.api.dto.OauthIdTokenResponse;
+import uttugseuja.lucklotteryserver.global.api.dto.OauthTokenResponse;
 
 @FeignClient(name = "KakaoAuthClient", url = "https://kauth.kakao.com")
 public interface KakaoOauthClient {
@@ -20,7 +19,7 @@ public interface KakaoOauthClient {
     @Headers("Content-type: application/x-www-form-urlencoded;charset=utf-8")
     @PostMapping(
             "/oauth/token?grant_type=authorization_code&client_id={CLIENT_ID}&redirect_uri={REDIRECT_URI}&code={CODE}")
-    OauthIdTokenResponse kakaoAuth(
+    OauthTokenResponse kakaoAuth(
             @PathVariable("CLIENT_ID") String clientId,
             @PathVariable("REDIRECT_URI") String redirectUri,
             @PathVariable("CODE") String code);

--- a/src/main/java/uttugseuja/lucklotteryserver/global/api/client/KakaoUnlinkClient.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/global/api/client/KakaoUnlinkClient.java
@@ -1,0 +1,17 @@
+package uttugseuja.lucklotteryserver.global.api.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "KakaoUnlinkClient", url = "https://kapi.kakao.com")
+public interface KakaoUnlinkClient {
+
+    @PostMapping(value = "/v1/user/unlink", consumes = "application/x-www-form-urlencoded")
+    void unlinkUser(
+            @RequestHeader("Authorization") String authorization,
+            @RequestParam(name = "target_id_type", defaultValue = "user_id") String targetIdType,
+            @RequestParam("target_id") Long targetId
+    );
+}

--- a/src/main/java/uttugseuja/lucklotteryserver/global/api/dto/OauthTokenResponse.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/global/api/dto/OauthTokenResponse.java
@@ -6,7 +6,10 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class OauthIdTokenResponse {
+public class OauthTokenResponse {
     @JsonProperty("id_token")
     private String idToken;
+
+    @JsonProperty("access_token")
+    private String accessToken;
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/global/api/dto/UserInfoToOauthDto.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/global/api/dto/UserInfoToOauthDto.java
@@ -1,0 +1,11 @@
+package uttugseuja.lucklotteryserver.global.api.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserInfoToOauthDto {
+    private String email;
+    private String id;
+}

--- a/src/main/java/uttugseuja/lucklotteryserver/global/property/OauthProperties.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/global/property/OauthProperties.java
@@ -21,6 +21,7 @@ public class OauthProperties {
         private String clientSecret;
         private String redirectUrl;
         private String appId;
+        private String adminKey;
     }
     public String getKakaoBaseUrl() {
         return kakao.getBaseUrl();
@@ -40,6 +41,10 @@ public class OauthProperties {
 
     public String getKakaoAppId() {
         return kakao.getAppId();
+    }
+
+    public String getKakaoAdminKey(){
+        return kakao.getAdminKey();
     }
 
     public String getGoogleBaseUrl() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,6 +32,7 @@ oauth:
     client-id: ${CLIENT_ID}
     redirect-url: ${REDIRECT_URL}
     base-url: ${BASE_URL}
+    admin-key: ${ADMIN_KEY}
   google:
     app-id: ${GOOGLE_APP_ID}
     redirect-url: ${GOOGLE_REDIRECT_URL}


### PR DESCRIPTION
resolved: #126 
## 작업내용
- 카카오 및 구글 소셜 로그인 연결 끊기 기능 구현
- oauth accessToken을 통해서 소셜 유저정보 가져오기 기능 구현
- 회원 탈퇴기능 구현(redis, 소셜 연결 끊기, 유저 정보 삭제)
- 유저 정보 제공 기능 구현
- 서버에서 소셜로그인을 통해서 idToken 만 받아오는 기능을 accessToken도 받아올 수 있도록 수정 
