### PR TITLE
Fix :  유저 닉네임 변경과 프로필 이미지 변경 한번에 처리하도록 기능 수정

### DIFF
--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/presentation/CredentialController.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/presentation/CredentialController.java
@@ -73,7 +73,7 @@ public class CredentialController {
     })
     public CheckRegisteredResponse valid(
             @RequestParam("idToken") String token,
-            @RequestParam("provider") OauthProvider oauthProvider) throws NoSuchAlgorithmException, InvalidKeySpecException {
+            @RequestParam("provider") OauthProvider oauthProvider) {
         log.info("controller token = {}",token);
         return credentialService.getUserAvailableRegister(token, oauthProvider);
     }
@@ -86,7 +86,7 @@ public class CredentialController {
     @PostMapping("/login")
     public AuthTokensResponse loginUser(
             @RequestParam("idToken") String token,
-            @RequestParam("provider") OauthProvider oauthProvider) throws NoSuchAlgorithmException, InvalidKeySpecException {
+            @RequestParam("provider") OauthProvider oauthProvider) {
         return credentialService.loginUserByOCIDToken(token, oauthProvider);
     }
 

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/user/presentation/UserController.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/user/presentation/UserController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.*;
 import uttugseuja.lucklotteryserver.domain.user.presentation.dto.request.ChangeNicknameRequest;
 import uttugseuja.lucklotteryserver.domain.user.presentation.dto.request.ChangeNotificationStatusRequest;
 import uttugseuja.lucklotteryserver.domain.user.presentation.dto.request.ChangeProfileRequest;
+import uttugseuja.lucklotteryserver.domain.user.presentation.dto.request.ChangeUserInfoRequest;
 import uttugseuja.lucklotteryserver.domain.user.presentation.dto.response.UserInfoResponse;
 import uttugseuja.lucklotteryserver.domain.user.presentation.dto.response.UserProfileResponse;
 import uttugseuja.lucklotteryserver.domain.user.service.UserService;
@@ -51,5 +52,11 @@ public class UserController {
     @GetMapping("/my/info")
     public UserInfoResponse getUserInfo(){
         return userService.getUserInfo();
+    }
+
+    @Operation(summary = "유저 정보 변경")
+    @PatchMapping("/update/my/info")
+    public UserInfoResponse changeUserInfo(@Valid @RequestBody ChangeUserInfoRequest changeUserInfoRequest){
+        return userService.changeUserInfo(changeUserInfoRequest);
     }
  }

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/user/presentation/dto/request/ChangeUserInfoRequest.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/user/presentation/dto/request/ChangeUserInfoRequest.java
@@ -1,0 +1,17 @@
+package uttugseuja.lucklotteryserver.domain.user.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.lang.Nullable;
+
+@Getter
+@NoArgsConstructor
+public class ChangeUserInfoRequest {
+
+    @Nullable
+    private String profilePath;
+
+    @NotNull
+    private String nickname;
+}

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/user/service/UserService.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/user/service/UserService.java
@@ -9,6 +9,7 @@ import uttugseuja.lucklotteryserver.domain.user.domain.User;
 import uttugseuja.lucklotteryserver.domain.user.presentation.dto.request.ChangeNicknameRequest;
 import uttugseuja.lucklotteryserver.domain.user.presentation.dto.request.ChangeNotificationStatusRequest;
 import uttugseuja.lucklotteryserver.domain.user.presentation.dto.request.ChangeProfileRequest;
+import uttugseuja.lucklotteryserver.domain.user.presentation.dto.request.ChangeUserInfoRequest;
 import uttugseuja.lucklotteryserver.domain.user.presentation.dto.response.UserInfoResponse;
 import uttugseuja.lucklotteryserver.domain.user.presentation.dto.response.UserProfileResponse;
 import uttugseuja.lucklotteryserver.global.utils.user.UserUtils;
@@ -65,4 +66,36 @@ public class UserService {
         User user = userUtils.getUserFromSecurityContext();
         return new UserInfoResponse(user.getUserInfo());
     }
+
+    @Transactional
+    public UserInfoResponse changeUserInfo(ChangeUserInfoRequest changeUserInfoRequest) {
+        User user = userUtils.getUserFromSecurityContext();
+        String nowProfilePath = user.getProfilePath();
+        String updateProfile = changeUserInfoRequest.getProfilePath();
+
+        if(updateProfile == null && nowProfilePath != null) {
+
+            deleteUserProfilePath(user.getProfilePath());
+            user.updateProfilePath(null);
+
+        }else if(updateProfile != null && nowProfilePath == null) {
+            user.updateProfilePath(updateProfile);
+
+        }else if(updateProfile != null && nowProfilePath != null){
+
+            if(!updateProfile.equals(nowProfilePath)){
+                deleteUserProfilePath(user.getProfilePath());
+                user.updateProfilePath(null);
+            }
+        }
+
+        if(!changeUserInfoRequest.getNickname().equals(user.getNickname())){
+            user.updateNickname(changeUserInfoRequest.getNickname());
+        }
+
+        return new UserInfoResponse(user.getUserInfo());
+
+    }
+
+
 }


### PR DESCRIPTION
resolved: #129 
## 작업내용
- 유저 닉네임 변경과 프로필 이미지 변경 Dto 생성
- 유저 닉네임 변경과 프로필 이미지 변경 처리하도록 기능 수정
