### PR TITLE
fix : 회원탈퇴 기능 수정

### DIFF
--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/exception/NotNullTokenException.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/exception/NotNullTokenException.java
@@ -1,0 +1,15 @@
+package uttugseuja.lucklotteryserver.domain.credential.exception;
+
+import uttugseuja.lucklotteryserver.global.error.exception.ErrorCode;
+import uttugseuja.lucklotteryserver.global.error.exception.LuckLotteryException;
+
+public class NotNullTokenException extends LuckLotteryException {
+
+    public static final LuckLotteryException EXCEPTION = new NotNullTokenException();
+
+    private NotNullTokenException() {
+        super(ErrorCode.NOT_NULL_TOKEN);
+    }
+
+
+}

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/exception/UserIdMismatchException.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/exception/UserIdMismatchException.java
@@ -1,0 +1,15 @@
+package uttugseuja.lucklotteryserver.domain.credential.exception;
+
+import uttugseuja.lucklotteryserver.global.error.exception.ErrorCode;
+import uttugseuja.lucklotteryserver.global.error.exception.LuckLotteryException;
+
+public class UserIdMismatchException extends LuckLotteryException {
+
+    public static final LuckLotteryException EXCEPTION = new UserIdMismatchException();
+
+    private UserIdMismatchException() {
+        super(ErrorCode.MISMATCH_USER_OAUTH_ID);
+    }
+
+
+}

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/presentation/dto/request/UnlinkRequest.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/presentation/dto/request/UnlinkRequest.java
@@ -1,0 +1,18 @@
+package uttugseuja.lucklotteryserver.domain.credential.presentation.dto.request;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UnlinkRequest {
+    private String accessToken;
+    private String oauthId;
+
+    public static UnlinkRequest createWithAccessToken(String accessToken) {
+        return UnlinkRequest.builder().accessToken(accessToken).build();
+    }
+
+    public static UnlinkRequest createWithOauthId(String oauthId) {
+        return UnlinkRequest.builder().oauthId(oauthId).build();
+    }
+}

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/CredentialService.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/CredentialService.java
@@ -6,8 +6,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import uttugseuja.lucklotteryserver.domain.credential.domain.RefreshTokenRedisEntity;
 import uttugseuja.lucklotteryserver.domain.credential.domain.repository.RefreshTokenRedisEntityRepository;
+import uttugseuja.lucklotteryserver.domain.credential.exception.NotNullTokenException;
 import uttugseuja.lucklotteryserver.domain.credential.exception.RefreshTokenExpiredException;
+import uttugseuja.lucklotteryserver.domain.credential.exception.UserIdMismatchException;
 import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.request.RegisterRequest;
+import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.request.UnlinkRequest;
 import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response.*;
 import uttugseuja.lucklotteryserver.domain.user.domain.User;
 import uttugseuja.lucklotteryserver.domain.user.domain.repository.UserRepository;
@@ -206,6 +209,15 @@ public class CredentialService {
     private void deleteUserData(User user) {
         refreshTokenRedisEntityRepository.deleteById(user.getId().toString());
         userRepository.delete(user);
+    }
+
+    private UnlinkRequest createUnlinkRequest(OauthProvider provider, String oauthAccessToken, String oauthId) {
+
+        if (provider.equals(OauthProvider.GOOGLE)) {
+            return UnlinkRequest.createWithAccessToken(oauthAccessToken);
+        } else {
+            return UnlinkRequest.createWithOauthId(oauthId);
+        }
     }
 
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/CredentialService.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/CredentialService.java
@@ -180,29 +180,30 @@ public class CredentialService {
         User user = userUtils.getUserFromSecurityContext();
         OauthProvider provider = OauthProvider.valueOf(user.getOauthProvider().toUpperCase());
         OauthStrategy oauthStrategy = oauthFactory.getOauthstrategy(provider);
+        String userOauthId = user.getOauthId();
 
         if(provider.equals(OauthProvider.GOOGLE)) {
-            validateGoogleUser(oauthAccessToken, user, oauthStrategy);
+            verifyUserOauthIdWithAccessToken(oauthAccessToken, userOauthId, oauthStrategy);
         }
 
         deleteUserData(user);
 
-        if(provider.equals(OauthProvider.GOOGLE)) {
-            oauthStrategy.unLink(oauthAccessToken);
-        }else {
-            oauthStrategy.unLink(user.getOauthId());
-        }
+        UnlinkRequest unlinkRequest = createUnlinkRequest(provider, oauthAccessToken, userOauthId);
+        oauthStrategy.unLink(unlinkRequest);
 
         user.withdrawal();
     }
 
-    private void validateGoogleUser(String oauthAccessToken, User user, OauthStrategy oauthStrategy) {
+    private void verifyUserOauthIdWithAccessToken(String oauthAccessToken, String oauthId, OauthStrategy oauthStrategy) {
+
         if(oauthAccessToken == null) {
-            throw InvalidTokenException.EXCEPTION;
+            throw NotNullTokenException.EXCEPTION;
         }
+
         UserInfoToOauthDto userInfo = oauthStrategy.getUserInfo(oauthAccessToken);
-        if (!userInfo.getId().equals(user.getOauthId())) {
-            throw InvalidTokenException.EXCEPTION;
+
+        if (!userInfo.getId().equals(oauthId)) {
+            throw UserIdMismatchException.EXCEPTION;
         }
     }
 

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/GoogleOauthStrategy.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/GoogleOauthStrategy.java
@@ -2,6 +2,7 @@ package uttugseuja.lucklotteryserver.domain.credential.service;
 
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
+import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.request.UnlinkRequest;
 import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response.OauthTokenInfoDto;
 import uttugseuja.lucklotteryserver.global.api.client.GoogleAuthClient;
 import uttugseuja.lucklotteryserver.global.api.client.GoogleUnlinkClient;
@@ -67,8 +68,11 @@ public class GoogleOauthStrategy implements OauthStrategy{
     }
 
     @Override
-    public void unLink(String oauthAccessToken) {
-        googleUnlinkClient.unlink(oauthAccessToken);
+    public void unLink(UnlinkRequest unlinkRequest) {
+        if (unlinkRequest.getAccessToken() != null) {
+            googleUnlinkClient.unlink(unlinkRequest.getAccessToken());
+        }
+
     }
 
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/KaKaoOauthStrategy.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/KaKaoOauthStrategy.java
@@ -30,7 +30,7 @@ public class KaKaoOauthStrategy implements OauthStrategy {
     @Override
     public OIDCDecodePayload getOIDCDecodePayload(String token){
         OIDCKeysResponse oidcKakaoKeysResponse = kakaoOauthClient.getKakaoOIDCOpenKeys();
-        return oauthOIDCProvider.getPayloadFromIdToken(token,ISSUER,oauthProperties.getKakaoClientId(),oidcKakaoKeysResponse);
+        return oauthOIDCProvider.getPayloadFromIdToken(token,ISSUER,oauthProperties.getKakaoAppId(),oidcKakaoKeysResponse);
     }
 
     @Override

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/KaKaoOauthStrategy.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/KaKaoOauthStrategy.java
@@ -3,6 +3,7 @@ package uttugseuja.lucklotteryserver.domain.credential.service;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.request.UnlinkRequest;
 import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response.OauthTokenInfoDto;
 import uttugseuja.lucklotteryserver.global.api.client.KakaoOauthClient;
 import uttugseuja.lucklotteryserver.global.api.client.KakaoUnlinkClient;
@@ -29,7 +30,7 @@ public class KaKaoOauthStrategy implements OauthStrategy {
     @Override
     public OIDCDecodePayload getOIDCDecodePayload(String token){
         OIDCKeysResponse oidcKakaoKeysResponse = kakaoOauthClient.getKakaoOIDCOpenKeys();
-        return oauthOIDCProvider.getPayloadFromIdToken(token,ISSUER,oauthProperties.getKakaoAppId(),oidcKakaoKeysResponse);
+        return oauthOIDCProvider.getPayloadFromIdToken(token,ISSUER,oauthProperties.getKakaoClientId(),oidcKakaoKeysResponse);
     }
 
     @Override
@@ -60,9 +61,13 @@ public class KaKaoOauthStrategy implements OauthStrategy {
     }
 
     @Override
-    public void unLink(String userOauthId) {
-        String kakaoAdminKey = oauthProperties.getKakaoAdminKey();
-        kakaoUnlinkClient.unlinkUser(PREFIX + kakaoAdminKey,TARGET_TYPE, Long.valueOf(userOauthId));
+    public void unLink(UnlinkRequest unlinkRequest) {
+
+        if (unlinkRequest.getOauthId() != null) {
+            String kakaoAdminKey = oauthProperties.getKakaoAdminKey();
+            kakaoUnlinkClient.unlinkUser(PREFIX + kakaoAdminKey,TARGET_TYPE, Long.valueOf(unlinkRequest.getOauthId()));
+        }
+
     }
 
 

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/OauthStrategy.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/OauthStrategy.java
@@ -1,5 +1,6 @@
 package uttugseuja.lucklotteryserver.domain.credential.service;
 
+import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.request.UnlinkRequest;
 import uttugseuja.lucklotteryserver.domain.credential.presentation.dto.response.OauthTokenInfoDto;
 import uttugseuja.lucklotteryserver.global.api.dto.UserInfoToOauthDto;
 
@@ -12,5 +13,5 @@ public interface OauthStrategy {
 
     UserInfoToOauthDto getUserInfo(String oauthAccessToken);
 
-    void unLink(String oauthAccessToken);
+    void unLink(UnlinkRequest unlinkRequest);
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/global/error/exception/ErrorCode.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/global/error/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
 
     /* 400 BAD_REQUEST : 잘못된 요청 */
     NOTIFICATION_FCM_TOKEN_INVALID(400, "FCM Token이 유효하지 않습니다."),
+    NOT_NULL_TOKEN(400, "토큰 값이 NULL일 수 없습니다"),
 
     /* 401 UNAUTHORIZED : 인증되지 않은 사용자 */
     INVALID_TOKEN(401, "토큰이 유효하지 않습니다."),

--- a/src/main/java/uttugseuja/lucklotteryserver/global/error/exception/ErrorCode.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/global/error/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     /* 400 BAD_REQUEST : 잘못된 요청 */
     NOTIFICATION_FCM_TOKEN_INVALID(400, "FCM Token이 유효하지 않습니다."),
     NOT_NULL_TOKEN(400, "토큰 값이 NULL일 수 없습니다"),
+    MISMATCH_USER_OAUTH_ID(400, "유저의  OAuth ID값이 토큰 ID 값과 일치하지 않습니다"),
 
     /* 401 UNAUTHORIZED : 인증되지 않은 사용자 */
     INVALID_TOKEN(401, "토큰이 유효하지 않습니다."),


### PR DESCRIPTION
resolved : #139 
## 작업 내용
- 소셜로그인 끊기 인터페이스 파라미터를 dto로 받을 수 있도록 변경 ouathToken -> (accessToken, oauthId) 두가지를 받도록 수정
- 수정된 인터페이스 카카오,구글 구현
- 회원 탈퇴시 발생 예외처리(토큰값이 null 일때 , accessToken 내부 id값과 유저 OauthId 값이 일치하지 않을 때)

