### PR TITLE
fix: 유저 프로필 변경 이미지 변경시 null -> 변경할 데이터로 수정

### DIFF
--- a/src/main/java/uttugseuja/lucklotteryserver/domain/user/service/UserService.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/user/service/UserService.java
@@ -85,7 +85,7 @@ public class UserService {
 
             if(!updateProfile.equals(nowProfilePath)){
                 deleteUserProfilePath(user.getProfilePath());
-                user.updateProfilePath(null);
+                user.updateProfilePath(updateProfile);
             }
         }
 


### PR DESCRIPTION
resolved : #147 
## 작업 내용
- 유저 프로필 변경 이미지 변경시 null -> 변경할 데이터로 수정
