### PR TITLE
fix :유저 정보 변경 기능 수정 

### DIFF
--- a/src/main/java/uttugseuja/lucklotteryserver/domain/image/service/ImageService.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/image/service/ImageService.java
@@ -14,10 +14,6 @@ import uttugseuja.lucklotteryserver.domain.image.exception.*;
 import uttugseuja.lucklotteryserver.domain.image.presentation.dto.UploadImageResponse;
 import uttugseuja.lucklotteryserver.global.utils.security.SecurityUtils;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 @RequiredArgsConstructor
@@ -39,20 +35,17 @@ public class ImageService implements ImageUtils{
     }
 
     public String upload(MultipartFile file) {
-        if (file.isEmpty() && file.getOriginalFilename() != null)
-            throw FileEmptyException.EXCEPTION;
 
-        if(file.getSize() / (1024 * 1024) > 10){
+        if (file.isEmpty() && file.getOriginalFilename() != null){
+            throw FileEmptyException.EXCEPTION;
+        }
+
+        if (file.getSize() / (1024 * 1024) > 10) {
             throw FileOversizeException.EXCEPTION;
         }
+
         String originalFilename = file.getOriginalFilename();
-        log.info("=====================originalFilename===========================");
-        log.info("originalFilename ={}",originalFilename);
-
         String ext = originalFilename.substring(originalFilename.lastIndexOf(".") + 1);
-
-        log.info("=====================ext===========================");
-        log.info("ext ={}",ext);
 
         if (!(ext.equals("jpg")
                 || ext.equals("HEIC")
@@ -63,7 +56,6 @@ public class ImageService implements ImageUtils{
         }
 
         String randomName = UUID.randomUUID().toString();
-
         String fileName = SecurityUtils.getCurrentUserId() + "|" + randomName + "." + ext;
 
         try {
@@ -77,7 +69,6 @@ public class ImageService implements ImageUtils{
         } catch (IOException e) {
             throw FileUploadFailException.EXCEPTION;
         }
-
         return baseUrl + "/" + fileName;
     }
 
@@ -88,15 +79,6 @@ public class ImageService implements ImageUtils{
     }
 
     public String getBucketKey(String profilePath){
-
-        try {
-            URI uri = new URI(profilePath);
-            String path = uri.getPath();
-            String idStr = path.substring(path.lastIndexOf('/') + 1);
-            return java.net.URLDecoder.decode(idStr, StandardCharsets.UTF_8.name());
-        } catch (URISyntaxException | UnsupportedEncodingException e) {
-            throw BadProfilePathException.EXCEPTION;
-        }
-
+        return profilePath.substring(profilePath.lastIndexOf('/') + 1);
     }
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/user/presentation/dto/request/ChangeUserInfoRequest.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/user/presentation/dto/request/ChangeUserInfoRequest.java
@@ -12,6 +12,6 @@ public class ChangeUserInfoRequest {
     @Nullable
     private String profilePath;
 
-    @Nullable
+    @NotNull
     private String nickname;
 }

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/user/service/UserService.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/user/service/UserService.java
@@ -45,21 +45,17 @@ public class UserService {
     @Transactional
     public void changeLotteryNotificationStatus(ChangeNotificationStatusRequest changeNotificationStatusRequest) {
         User user = userUtils.getUserFromSecurityContext();
-
         user.updateLotteryNotificationStatus(changeNotificationStatusRequest.getNotificationStatus());
     }
 
     @Transactional
     public void changePensionLotteryNotificationStatus(ChangeNotificationStatusRequest changeNotificationStatusRequest) {
         User user = userUtils.getUserFromSecurityContext();
-
         user.updatePensionLotteryNotificationStatus(changeNotificationStatusRequest.getNotificationStatus());
     }
 
     private void deleteUserProfilePath(String profilePath){
-
         imageUtils.delete(profilePath);
-
     }
 
     public UserInfoResponse getUserInfo() {
@@ -73,29 +69,24 @@ public class UserService {
         String nowProfilePath = user.getProfilePath();
         String updateProfile = changeUserInfoRequest.getProfilePath();
 
-        if(updateProfile == null && nowProfilePath != null) {
-
+        if (updateProfile == null && nowProfilePath != null) {
             deleteUserProfilePath(user.getProfilePath());
             user.updateProfilePath(null);
-
-        }else if(updateProfile != null && nowProfilePath == null) {
+        }else if (updateProfile != null && nowProfilePath == null) {
             user.updateProfilePath(updateProfile);
+        }else if (updateProfile != null && nowProfilePath != null) {
 
-        }else if(updateProfile != null && nowProfilePath != null){
-
-            if(!updateProfile.equals(nowProfilePath)){
+            if (!updateProfile.equals(nowProfilePath)) {
                 deleteUserProfilePath(user.getProfilePath());
                 user.updateProfilePath(updateProfile);
             }
+
         }
 
-        if(!(changeUserInfoRequest.getNickname() == null)){
+        if (!changeUserInfoRequest.getNickname().equals(user.getNickname())) {
             user.updateNickname(changeUserInfoRequest.getNickname());
         }
 
         return new UserInfoResponse(user.getUserInfo());
-
     }
-
-
 }


### PR DESCRIPTION
resolved : #151 
## 작업 내용
- 유저 닉네임 변경 할때 null 사용할 수 없도록 수정
- 유저 프로필 변경시 기존 프로필이미지 삭제  BucketKey를 파싱할 때 문자열로 처리하도록 수정
- 유저 정보 변경 기능 로그 제거