### PR TITLE
fix : 회원 탈퇴 시 자식 Entity 같이 삭제

### DIFF
--- a/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/CredentialService.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/credential/service/CredentialService.java
@@ -45,7 +45,7 @@ public class CredentialService {
     public void logoutUser() {
         User user = userUtils.getUserFromSecurityContext();
         refreshTokenRedisEntityRepository.deleteById(user.getId().toString());
-        user.logout();
+        user.handleDeleteDeviceToken();
     }
 
     @Transactional
@@ -186,12 +186,12 @@ public class CredentialService {
             verifyUserOauthIdWithAccessToken(oauthAccessToken, userOauthId, oauthStrategy);
         }
 
+        user.handleDeleteDeviceToken();
+
         deleteUserData(user);
 
         UnlinkRequest unlinkRequest = createUnlinkRequest(provider, oauthAccessToken, userOauthId);
         oauthStrategy.unLink(unlinkRequest);
-
-        user.withdrawal();
     }
 
     private void verifyUserOauthIdWithAccessToken(String oauthAccessToken, String oauthId, OauthStrategy oauthStrategy) {

--- a/src/main/java/uttugseuja/lucklotteryserver/domain/user/domain/User.java
+++ b/src/main/java/uttugseuja/lucklotteryserver/domain/user/domain/User.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.lang.Nullable;
+import uttugseuja.lucklotteryserver.domain.lottery.domain.Lottery;
 import uttugseuja.lucklotteryserver.domain.notification.event.DeviceTokenEvent;
 import uttugseuja.lucklotteryserver.domain.pensionlottery.domain.PensionLottery;
 import uttugseuja.lucklotteryserver.domain.user.domain.vo.UserInfoVO;
@@ -44,6 +45,9 @@ public class User {
     private Boolean lotteryNotificationStatus;
 
     private Boolean pensionLotteryNotificationStatus;
+
+    @OneToMany(mappedBy = "user",cascade = CascadeType.ALL)
+    private List<Lottery> lotteries = new ArrayList<>();
 
     @Builder
     public User(
@@ -95,15 +99,7 @@ public class User {
         return User.builder().id(userId).build();
     }
 
-    public void logout() {
-        handleDeleteDeviceToken();
-    }
-
-    public void withdrawal() {
-        handleDeleteDeviceToken();
-    }
-
-    private void handleDeleteDeviceToken() {
+    public void handleDeleteDeviceToken() {
         DeviceTokenEvent deviceTokenEvent = new DeviceTokenEvent(User.of(id));
         Events.raise(deviceTokenEvent);
     }


### PR DESCRIPTION
resolved : #153 
## 작업내용
- logout Event, withdrawal Event를 handleDeleteDeviceToken으로 통합
- 양방향 연관관계로 자식 Entity 같이 삭제